### PR TITLE
Allow newer versions of selectize

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,6 @@
     "./dist/selectize.js"
   ],
   "dependencies": {
-    "selectize": "~0.9.0"
+    "selectize": ">=0.9.0"
   }
 }


### PR DESCRIPTION
Version 0.10.0 and 0.10.1 are available. Relax the version constraint so
these can be used.
