### PR TITLE
scope.$evalAsync instead of $timeout

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -88,7 +88,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       }
 
       //init
-      $timeout(function(){
+      scope.$evalAsync(function(){
 
         parseConfig();
         element.selectize(config);


### PR DESCRIPTION
Have you considered evalAsync?  If you implement this you may want to make bower require angular >= 1.2.  Some reasons are at:

http://www.bennadel.com/blog/2605-scope-evalasync-vs-timeout-in-angularjs.htm

and 

http://stackoverflow.com/questions/17301572/angularjs-evalasync-vs-timeout

and a plnkr fork of your example using the eval async:

http://plnkr.co/edit/o0DMkE6UERSIr9IMDyXi?p=preview

It feels slightly faster although I haven't benchmarked it.
