### PR TITLE
Default config wasn't default...

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -9,15 +9,14 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
     require: '^ngModel',
     scope: {ngModel: '=', config: '=selectize', options: '=', ngDisabled: '='},
     link: function(scope, element, attrs, modelCtrl) {
-      var config = angular.copy(scope.config);
+      var config = angular.copy(selectizeConfig);
       var selectize;
 
-      function parseConfig(){
+      function parseConfig() {
         config.options = scope.options || [];
 
-        if (typeof selectizeConfig !== 'undefined') {
-          var defaultConfig = angular.copy(selectizeConfig);
-          config = angular.extend(defaultConfig, config);
+        if (typeof scope.config !== 'undefined') {
+          config = angular.extend(config, scope.config);
         }
         config.maxItems = config.maxItems || null; //default to tag editor
 


### PR DESCRIPTION
I've made a small change to the directive so that default config actually becomes default. In the current implementation it's mandatory to pass config to each instance of selectize. With my change, you can define 

``` coffeescript
MyApp.value('selectizeConfig', {
  valueField: 'id'
  labelField: 'name'
  searchField: 'name'
  maxItems: 1
  preload: true
})
```

as the readme suggests and then the above is used as default. Once you've defined the default config you can create an instance with just

``` html
<selectize options='myOptions' ng-model="myModel"></selectize>
```

Previously the above line threw an error since `scope.config` is not defined. If you want to override some default config, you can still initiate the directive as before i.e.

``` html
<div selectize="{placeholder:'Pick Something'}" options='myOptions' ng-model="myModel"></div>
```
