### PR TITLE
fix(selectize): prevent memory leak by cleaning up on $destroy

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -153,6 +153,15 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       scope.$watchCollection('options', updateSelectizeOptions);
       scope.$watch('ngModel', updateSelectizeValue, true);
       scope.$watch('ngDisabled', toggle);
+
+      element.on('$destroy', function() {
+          if (selectize) {
+              selectize.destroy();
+              element = null;
+          }
+      });
+
+
     }
   };
 }]);


### PR DESCRIPTION
If the selectize control is added and removed there are some listeners that remain that prevent garbage collection.  Listen to the `$destroy` event, destroy the selectize component and cleanup the element.
