### PR TITLE
Fixed not working validation on Angular 1.3.x

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -62,7 +62,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       }
 
       function updateValidity(){
-        modelCtrl.$setValidity('required', !config.required || scope.ngModel.length)
+        modelCtrl.$setValidity('required', !config.required || scope.ngModel.length !== 0 ? true : false)
         updateClasses();
       }
 


### PR DESCRIPTION
Angular 1.3.x doesn't accept numbers to bool conversion in $setValidity()
