### PR TITLE
Angular 1.3.x Pass copy of object to $setViewValue

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -54,7 +54,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       }
 
       function setDirty(){
-        modelCtrl.$setViewValue(modelCtrl.$modelValue);
+        modelCtrl.$setViewValue(angular.copy(modelCtrl.$modelValue));
       }
 
       function updateClasses(){


### PR DESCRIPTION
According to https://code.angularjs.org/1.3.3/docs/api/ng/type/ngModel.NgModelController we need to pass copy of object to $setViewValue in order for dirty checking and validation to work properly. This commit fixes the issue.
