### PR TITLE
Do not return an array if maxItems is 1

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -63,7 +63,11 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       config.onChange = function(){
         if( !angular.equals(selectize.items, scope.ngModel) )
           scope.$evalAsync(function(){
-            modelCtrl.$setViewValue( angular.copy(selectize.items) );
+            var value = angular.copy(selectize.items);
+            if (config.maxItems && config.maxItems == 1) {
+              value = value[0]
+            }
+            modelCtrl.$setViewValue( value );
           });
       }
 


### PR DESCRIPTION
I'm not sure when it happened, but I updated your script today and found that the value returned was always an array even if maxItems was 0. This is a small fix that returns the only value in this situation so it's easier to use as a replacement to e.g. bs-select and ui-select.