### PR TITLE
fix(options): fully reset options on watch change + opportunistic linting

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -1,9 +1,11 @@
+'use strict';
+
 /**
  * Angular Selectize2
  * https://github.com/machineboy2045/angular-selectize
  **/
 
-angular.module('selectize', []).value('selectizeConfig', {}).directive("selectize", ['selectizeConfig', function(selectizeConfig) {
+angular.module('selectize', []).value('selectizeConfig', {}).directive('selectize', ['selectizeConfig', function(selectizeConfig) {
   return {
     restrict: 'E',
     require: '^ngModel',
@@ -17,7 +19,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
 
       modelCtrl.$isEmpty = function(val){
         return (val === undefined || val === null || !val.length); //override to support checking empty arrays
-      }
+      };
 
       function createItem(input) {
         var data = {};
@@ -27,19 +29,23 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       }
 
       function toggle(disabled){
-        disabled ? selectize.disable() : selectize.enable();
+        if (disabled) {
+          selectize.disable();
+        } else {
+          selectize.enable();
+        }
       }
 
       var validate = function() {
         var isInvalid = config.required && modelCtrl.$isEmpty(scope.ngModel);
-        modelCtrl.$setValidity('required', !isInvalid)
+        modelCtrl.$setValidity('required', !isInvalid);
       };
 
       function generateOptions(data){
         if(!data)
           return [];
           
-        data = angular.isArray(data) ? data : [data]
+        data = angular.isArray(data) ? data : [data];
 
         return $.map(data, function(opt){
           return typeof opt === 'string' ? createItem(opt) : opt;
@@ -49,14 +55,14 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       function updateSelectize(){
         validate();
 
-        selectize.$control.toggleClass('ng-valid', modelCtrl.$valid)
-        selectize.$control.toggleClass('ng-invalid', modelCtrl.$invalid)
-        selectize.$control.toggleClass('ng-dirty', modelCtrl.$dirty)
-        selectize.$control.toggleClass('ng-pristine', modelCtrl.$pristine)
+        selectize.$control.toggleClass('ng-valid', modelCtrl.$valid);
+        selectize.$control.toggleClass('ng-invalid', modelCtrl.$invalid);
+        selectize.$control.toggleClass('ng-dirty', modelCtrl.$dirty);
+        selectize.$control.toggleClass('ng-pristine', modelCtrl.$pristine);
 
         if( !angular.equals(selectize.items, scope.ngModel) ){
-          selectize.addOption(generateOptions(scope.ngModel))
-          selectize.setValue(scope.ngModel)
+          selectize.addOption(generateOptions(scope.ngModel));
+          selectize.setValue(scope.ngModel);
         }
       }
       
@@ -65,12 +71,12 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
           scope.$evalAsync(function(){
             modelCtrl.$setViewValue( angular.copy(selectize.items) );
           });
-      }
+      };
 
       config.onOptionAdd = function(value, data) {
         if( scope.options.indexOf(data) === -1 )
           scope.options.push(data);
-      }
+      };
 
       // ngModel (ie selected items) is included in this because if no options are specified, we
       // need to create the corresponding options for the items to be visible
@@ -78,13 +84,18 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
 
       config.onInitialize = function(){
         selectize = element[0].selectize;
-        selectize.addOption(scope.options)
-        selectize.setValue(scope.ngModel)
+        selectize.addOption(scope.options);
+        selectize.setValue(scope.ngModel);
 
-        scope.$watchCollection('options', selectize.addOption.bind(selectize));
+        // rebuild options if updated
+        scope.$watchCollection('options', function() {
+          selectize.clearOptions();
+          selectize.addOption(scope.options); 
+        });
+
         scope.$watch('ngModel', updateSelectize);
         scope.$watch('ngDisabled', toggle);
-      }
+      };
 
       element.selectize(config);
 


### PR DESCRIPTION
Ran into an issue where re-assigning `options` would only append new values, not reset as expected.

Also did some opportunistic linting (no formatting changes).