### PR TITLE
Update state properly when options are loaded async

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -104,7 +104,11 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
           angularCallback(selectize);
         }
 
-        scope.$watchCollection('options', selectize.addOption.bind(selectize));
+        scope.$watchCollection('options', function(options) {
+          selectize.clearOptions();
+          selectize.addOption(options);
+          selectize.setValue(scope.ngModel);
+        });
         scope.$watch('ngModel', updateSelectize);
         scope.$watch('ngDisabled', toggle);
       }


### PR DESCRIPTION
The directive does not work properly if the options are loaded async but the model is already set. This is due to these lines which always create an initial entry in selectize.

```javascript
  if( !angular.equals(selectize.items, scope.ngModel) ){
    selectize.addOption(generateOptions(scope.ngModel))
    selectize.setValue(scope.ngModel)
  }
```

I'm not sure what the purpose of those lines are (selectize.items is an Array so won't be equal to the model) but I've left them as they are.

What's more this entry is always wrong since the label field will default to the value.

When the options are finally loaded they are added to addOption but the initially created option remains and is always on top. The correct value with a proper label field is not added since there already exists an option with that value (the one created above).

My update fixes this by first clearing all the old options (in my case only the initial faulty one), then adds the new options, and then sets the value to the model again. Now the correct option is added properly, has the intended label and is also positioned properly in the list.