### PR TITLE
Removed angular.copy instruction

### DIFF
--- a/dist/selectize.js
+++ b/dist/selectize.js
@@ -66,7 +66,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       config.onChange = function(){
         if( !angular.equals(selectize.items, scope.ngModel) )
           scope.$evalAsync(function(){
-            var value = angular.copy(selectize.items);
+            var value = selectize.items;
             if (config.maxItems == 1) {
               value = value[0]
             }
@@ -89,7 +89,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
 
       // ngModel (ie selected items) is included in this because if no options are specified, we
       // need to create the corresponding options for the items to be visible
-      scope.options = generateOptions( angular.copy(scope.options || config.options || scope.ngModel) );
+      scope.options = generateOptions( scope.options || config.options || scope.ngModel);
       
       var angularCallback = config.onInitialize;
 


### PR DESCRIPTION
I found this dramatically affected performance when dealing with a great number of items (10000+).

The digest loop went from 3.5s+ to < 500ms.

Would like to discuss this further, maybe by adding an options to enable/disable this behaviour.