### PR TITLE
Allow dynamic loading of individual selectize options

### DIFF
--- a/dist/angular-selectize.js
+++ b/dist/angular-selectize.js
@@ -52,7 +52,20 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
         selectize.$control.toggleClass('ng-pristine', modelCtrl.$pristine);
 
         if (!angular.equals(selectize.items, scope.ngModel)) {
-          selectize.setValue(scope.ngModel, true);
+
+            if (scope.ngModel != null
+                && selectize.getOption(scope.ngModel).length == 0
+                && scope.config.fetchOption) {
+
+                scope.config.fetchOption(scope.ngModel, function (item) {
+                    selectize.addOption(item);
+                    selectize.setValue(scope.ngModel, true);
+                })
+
+            } else {
+                selectize.setValue(scope.ngModel, true);
+            }
+
         }
       }
 

--- a/dist/angular-selectize.js
+++ b/dist/angular-selectize.js
@@ -52,7 +52,20 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
         selectize.$control.toggleClass('ng-pristine', modelCtrl.$pristine);
 
         if (!angular.equals(selectize.items, scope.ngModel)) {
-          selectize.setValue(scope.ngModel, true);
+
+            if (scope.ngModel != null
+                && selectize.getOption(scope.ngModel).length == 0
+                && scope.config.fetchOption) {
+
+                scope.config.fetchOption(scope.ngModel, function (item) {
+                    selectize.addOption(item);
+                    selectize.setValue(scope.ngModel, true);
+                });
+
+            } else {
+                selectize.setValue(scope.ngModel, true);
+            }
+
         }
       }
 

--- a/dist/angular-selectize.js
+++ b/dist/angular-selectize.js
@@ -52,20 +52,7 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
         selectize.$control.toggleClass('ng-pristine', modelCtrl.$pristine);
 
         if (!angular.equals(selectize.items, scope.ngModel)) {
-
-            if (scope.ngModel != null
-                && selectize.getOption(scope.ngModel).length == 0
-                && scope.config.fetchOption) {
-
-                scope.config.fetchOption(scope.ngModel, function (item) {
-                    selectize.addOption(item);
-                    selectize.setValue(scope.ngModel, true);
-                })
-
-            } else {
-                selectize.setValue(scope.ngModel, true);
-            }
-
+          selectize.setValue(scope.ngModel, true);
         }
       }
 


### PR DESCRIPTION
There may be a better way to do this than the way I have in this pull request, but it would be extremely useful for angular-selectize to be able to fetch unloaded options via a callback.

This enables users of angular-selectize to (optionally) provide default values or to change the selectize model externally and have the options loaded as needed - sorely needed when you're using ajax.