### PR TITLE
Support angular without jquery

### DIFF
--- a/dist/angular-selectize.js
+++ b/dist/angular-selectize.js
@@ -93,8 +93,8 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
         scope.$watch('ngModel', setSelectizeValue);
         scope.$watch('ngDisabled', toggle);
       };
-
-      element.selectize(settings);
+      // we must to check for library in element prototype, if not - we should to append it
+      (element.jquery?element:jQuery(element)).selectize(settings);
 
       element.on('$destroy', function() {
         if (selectize) {


### PR DESCRIPTION
There are cases where angular is used without jquery (with jqlite). If so then executing 'element.selectize()' will throw error that selectize is undefined. To fix that we should to check jquery in element prototype and re-initialize element with jQuery on fail.
