### PR TITLE
Add 'main' entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,5 +2,6 @@
   "name": "angular-selectize2",
   "description": "This is an Angular.js directive for Brian Reavis's selectize jQuery plugin. It supports all of Selectize's features",
   "version": "v3.0.1",
+  "main": "dist/selectize.js",
   "private": false
 }


### PR DESCRIPTION
Allow the library to be require()-d from `node_modules` by specifying the main dist file in package.json.

I'm not sure what the policy is around editing CHANGELOG.md, should I bump the version and add an entry as part of this PR? Assuming you think this change is worth merging in, of course.
