### PR TITLE
Set `null` as empty value instead of `undefined`

### DIFF
--- a/dist/angular-selectize.js
+++ b/dist/angular-selectize.js
@@ -59,7 +59,13 @@ angular.module('selectize', []).value('selectizeConfig', {}).directive("selectiz
       settings.onChange = function(value) {
         var value = angular.copy(selectize.items);
         if (settings.maxItems == 1) {
-          value = value[0]
+          value = value[0];
+
+          //set null instead of undefined to keep the attribute in
+          //a serialized JSON
+          if (typeof value === 'undefined') {
+            value = null;
+          }
         }
         modelCtrl.$setViewValue( value );
 


### PR DESCRIPTION
Setting `undefined` for an attribute on an object that is going to be serialized as JSON will cause the attribute to be skipped from the JSON. I think this is not what is usually needed to empty values as most REST APIs will either throw an error (as a mandatory attribute is not in the API call) or will not update the attributes value.

Setting `null` as empty value instead of `undefined` solves this problem.