### PR TITLE
Fix for https://github.com/machineboy2045/angular-selectize/issues/159 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.2 (2017-03-26)
+
+Changes:
+
+  - Updated version so a new tag/release can be created where the version in the package.json version matches the tag/release version 
+  
 ## 3.0.1 (2015-09-07)
 
 Documentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
-## 3.0.3 (2017-03-26)
-
-Changes:
-
-  - Updated package.json so it was valid. 
-
 ## 3.0.2 (2017-03-26)
 
 Changes:
 
   - Updated version so a new tag/release can be created where the version in the package.json version matches the tag/release version 
+  - Updated package.json so it was valid.
   
 ## 3.0.1 (2015-09-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.3 (2017-03-26)
+
+Changes:
+
+  - Updated package.json so it was valid. 
+
 ## 3.0.2 (2017-03-26)
 
 Changes:

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-selectize2",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "main" : [
     "./dist/angular-selectize.js"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-selectize2",
   "description": "This is an Angular.js directive for Brian Reavis's selectize jQuery plugin. It supports all of Selectize's features",
-  "version": "v3.0.1",
+  "version": "v3.0.2",
   "private": false
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,29 @@
 {
   "name": "angular-selectize2",
+  "keywords": [
+    "select",
+    "ui",
+    "form",
+    "input",
+    "control",
+    "autocomplete",
+    "tagging",
+    "angular",
+    "directive",
+    "tag"
+  ],
+  "main": "dist/angular-selectize.js",
   "description": "This is an Angular.js directive for Brian Reavis's selectize jQuery plugin. It supports all of Selectize's features",
   "version": "v3.0.2",
-  "private": false
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/machineboy2045/angular-selectize.git"
+  },
+  "dependencies": {
+    "selectize": ">=0.12.1"
+  },
+  "engines": {
+    "node": "*"
+  }
 }


### PR DESCRIPTION
This is a fix for issue https://github.com/machineboy2045/angular-selectize/issues/159.  A new 3.0.2 release/tag should be done and published to NPM and Bower after these changes. 